### PR TITLE
retorno do método alterado de objeto para string

### DIFF
--- a/src/main/java/br/com/fiap/ez/fastfood/adapters/in/controller/OrderController.java
+++ b/src/main/java/br/com/fiap/ez/fastfood/adapters/in/controller/OrderController.java
@@ -75,8 +75,7 @@ public class OrderController {
 			@ApiResponse(responseCode = "400", description = "Invalid input data") })
 	@PostMapping(path = "/notify-payment-status", produces = "application/json")
 	public ResponseEntity<?> notifyOrderPaymentStatus (@Valid @RequestBody PaymentIntegrationDTO dto) {
-		
-		return new ResponseEntity<>(orderUseCase.notifyOrderPaymentStatus(dto), HttpStatus.OK);
+		return new ResponseEntity<>(orderUseCase.notifyOrderPaymentStatus(dto).getOrderStatus().toString(), HttpStatus.OK);
 	}
 
 }


### PR DESCRIPTION
Trecho de código adicionado para tratativas, uma vez que o OrderResponseDTO no payment-ms espera somente uma string e não o objeto inteiro.
![image](https://github.com/user-attachments/assets/af68567e-9f0f-4556-aaf0-1088a391bd07)
